### PR TITLE
docs: escaping pathname

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ append-xxhsum [--xxhsum-filepath FILEPATH] \
 
 | param | long-param | description |
 | -- | -- | -- |
-| -x | --xxhsum-filepath | FILEPATH of file to append to. Defaults to PATH\..\DIRNAME.xxhsum |
+| -x | --xxhsum-filepath | FILEPATH of file to append to. Defaults to PATH\\..\\DIRNAME.xxhsum |
 | -b | --bsd-style | BSD-style checksum lines. Defaults to GNU-style |
 | -v | --verbose | increase the verbosity |
 | -d | --debug | show debug information |


### PR DESCRIPTION
Fixed readme